### PR TITLE
Implement Cribl Terraform Provider Authentication

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,10 +3,10 @@ id: b2744b7e-1ce3-478a-8c1f-0348b936141a
 management:
   docChecksum: 3bd5759622b767560b30a6d95d2ed425
   docVersion: 1.0.0
-  speakeasyVersion: 1.540.0
-  generationVersion: 2.593.3
-  releaseVersion: 0.11.7
-  configChecksum: f7f337d7b5ba830555e212482b288652
+  speakeasyVersion: 1.540.1
+  generationVersion: 2.593.4
+  releaseVersion: 0.11.10
+  configChecksum: e7c76a2f4286e41a086f36a3a206818e
   published: true
 features:
   terraform:

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 1.0.0
   speakeasyVersion: 1.540.0
   generationVersion: 2.593.3
-  releaseVersion: 0.11.2
-  configChecksum: dd750c09b0afe18022ad9e097c80512b
+  releaseVersion: 0.11.7
+  configChecksum: f7f337d7b5ba830555e212482b288652
   published: true
 features:
   terraform:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -11,11 +11,12 @@ generation:
     parameterOrderingFeb2024: true
     requestResponseComponentNamesFeb2024: true
     securityFeb2025: true
+    sharedErrorComponentsApr2025: false
   auth:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 terraform:
-  version: 0.11.7
+  version: 0.11.10
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -15,16 +15,23 @@ generation:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 terraform:
-  version: 0.11.2
+  version: 0.11.7
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []
   additionalProviderAttributes:
+    audience: ""
     httpHeaders: ""
   additionalResources: []
   allowUnknownFieldsInWeakUnions: false
   author: speakeasy
   defaultErrorName: APIError
   enableTypeDeduplication: false
-  environmentVariables: []
+  environmentVariables:
+    - env: CRIBL_CLIENT_ID
+      providerAttribute: client_id
+    - env: CRIBL_CLIENT_SECRET
+      providerAttribute: client_secret
+    - env: CRIBL_TOKEN_URL
+      providerAttribute: token_url
   packageName: cribl-terraform

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,7 +2,7 @@ speakeasyVersion: 1.540.0
 sources:
     Cribl API Reference:
         sourceNamespace: cribl-api-reference
-        sourceRevisionDigest: sha256:9ec3a89052bbc5e9cfe06b6b6a68033e680548bea300b0b288114a6c3480416e
+        sourceRevisionDigest: sha256:5299d5f13a4a00b3e2be94c3ab3df611a91002fd2d244c0f2b4508d7f2ec866d
         sourceBlobDigest: sha256:f1673b088f5dc45a4d10fe7e57770df5969e6971b67f064fc970d81ed64056ac
         tags:
             - latest
@@ -11,7 +11,7 @@ targets:
     cribl-terraform:
         source: Cribl API Reference
         sourceNamespace: cribl-api-reference
-        sourceRevisionDigest: sha256:9ec3a89052bbc5e9cfe06b6b6a68033e680548bea300b0b288114a6c3480416e
+        sourceRevisionDigest: sha256:5299d5f13a4a00b3e2be94c3ab3df611a91002fd2d244c0f2b4508d7f2ec866d
         sourceBlobDigest: sha256:f1673b088f5dc45a4d10fe7e57770df5969e6971b67f064fc970d81ed64056ac
 workflow:
     workflowVersion: 1.0.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,8 +1,8 @@
-speakeasyVersion: 1.540.0
+speakeasyVersion: 1.540.1
 sources:
     Cribl API Reference:
         sourceNamespace: cribl-api-reference
-        sourceRevisionDigest: sha256:5299d5f13a4a00b3e2be94c3ab3df611a91002fd2d244c0f2b4508d7f2ec866d
+        sourceRevisionDigest: sha256:b3aba3622db2cf4ab18173e8e2585299868503fa8dcf4ed4bd22bf27c58cfcd1
         sourceBlobDigest: sha256:f1673b088f5dc45a4d10fe7e57770df5969e6971b67f064fc970d81ed64056ac
         tags:
             - latest
@@ -11,7 +11,7 @@ targets:
     cribl-terraform:
         source: Cribl API Reference
         sourceNamespace: cribl-api-reference
-        sourceRevisionDigest: sha256:5299d5f13a4a00b3e2be94c3ab3df611a91002fd2d244c0f2b4508d7f2ec866d
+        sourceRevisionDigest: sha256:b3aba3622db2cf4ab18173e8e2585299868503fa8dcf4ed4bd22bf27c58cfcd1
         sourceBlobDigest: sha256:f1673b088f5dc45a4d10fe7e57770df5969e6971b67f064fc970d81ed64056ac
 workflow:
     workflowVersion: 1.0.0

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ terraform {
   required_providers {
     cribl-terraform = {
       source  = "speakeasy/cribl-terraform"
-      version = "0.11.2"
+      version = "0.11.7"
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ terraform {
   required_providers {
     cribl-terraform = {
       source  = "speakeasy/cribl-terraform"
-      version = "0.11.7"
+      version = "0.11.10"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     cribl-terraform = {
       source  = "speakeasy/cribl-terraform"
-      version = "0.11.2"
+      version = "0.11.7"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     cribl-terraform = {
       source  = "speakeasy/cribl-terraform"
-      version = "0.11.7"
+      version = "0.11.10"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cribl-terraform = {
       source  = "speakeasy/cribl-terraform"
-      version = "0.11.2"
+      version = "0.11.7"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cribl-terraform = {
       source  = "speakeasy/cribl-terraform"
-      version = "0.11.7"
+      version = "0.11.10"
     }
   }
 }

--- a/internal/sdk/criblterraform.go
+++ b/internal/sdk/criblterraform.go
@@ -417,9 +417,9 @@ func New(opts ...SDKOption) *CriblTerraform {
 		sdkConfiguration: sdkConfiguration{
 			Language:          "go",
 			OpenAPIDocVersion: "1.0.0",
-			SDKVersion:        "0.11.2",
+			SDKVersion:        "0.11.7",
 			GenVersion:        "2.593.3",
-			UserAgent:         "speakeasy-sdk/terraform 0.11.2 2.593.3 1.0.0 github.com/speakeasy/terraform-provider-cribl-terraform/internal/sdk",
+			UserAgent:         "speakeasy-sdk/terraform 0.11.7 2.593.3 1.0.0 github.com/speakeasy/terraform-provider-cribl-terraform/internal/sdk",
 			ServerDefaults: map[string]map[string]string{
 				"cloud": {
 					"workspaceName":  "main",

--- a/internal/sdk/criblterraform.go
+++ b/internal/sdk/criblterraform.go
@@ -417,9 +417,9 @@ func New(opts ...SDKOption) *CriblTerraform {
 		sdkConfiguration: sdkConfiguration{
 			Language:          "go",
 			OpenAPIDocVersion: "1.0.0",
-			SDKVersion:        "0.11.7",
-			GenVersion:        "2.593.3",
-			UserAgent:         "speakeasy-sdk/terraform 0.11.7 2.593.3 1.0.0 github.com/speakeasy/terraform-provider-cribl-terraform/internal/sdk",
+			SDKVersion:        "0.11.10",
+			GenVersion:        "2.593.4",
+			UserAgent:         "speakeasy-sdk/terraform 0.11.10 2.593.4 1.0.0 github.com/speakeasy/terraform-provider-cribl-terraform/internal/sdk",
 			ServerDefaults: map[string]map[string]string{
 				"cloud": {
 					"workspaceName":  "main",

--- a/internal/sdk/internal/hooks/cribl_terraform_auth_hook.go
+++ b/internal/sdk/internal/hooks/cribl_terraform_auth_hook.go
@@ -1,0 +1,170 @@
+package hooks
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+type CriblTerraformAuthHook struct {
+	client   HTTPClient
+	sessions sync.Map
+}
+
+type CriblConfig struct {
+	ClientID     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+}
+
+var (
+	_ sdkInitHook       = (*CriblTerraformAuthHook)(nil)
+	_ beforeRequestHook = (*CriblTerraformAuthHook)(nil)
+)
+
+func NewCriblTerraformAuthHook() *CriblTerraformAuthHook {
+	log.Printf("[DEBUG] Creating new Cribl Terraform authentication hook")
+	return &CriblTerraformAuthHook{}
+}
+
+func (o *CriblTerraformAuthHook) SDKInit(baseURL string, client HTTPClient) (string, HTTPClient) {
+	log.Printf("[DEBUG] Initializing Cribl Terraform authentication hook with baseURL: %s", baseURL)
+	o.client = client
+	return baseURL, client
+}
+
+func (o *CriblTerraformAuthHook) BeforeRequest(ctx BeforeRequestContext, req *http.Request) (*http.Request, error) {
+	log.Printf("[DEBUG] Cribl Terraform authentication hook: BeforeRequest for operation: %s", ctx.OperationID)
+
+	// Check for bearer token in environment variable
+	if bearerToken := os.Getenv("CRIBL_BEARER_TOKEN"); bearerToken != "" {
+		log.Printf("[DEBUG] Found CRIBL_BEARER_TOKEN in environment")
+		req.Header.Set("Authorization", "Bearer "+bearerToken)
+		return req, nil
+	}
+
+	// Get credentials from config or environment
+	config, err := o.getCredentialsFromConfig()
+	if err != nil {
+		log.Printf("[DEBUG] Failed to get credentials: %v", err)
+		return req, nil
+	}
+
+	if config != nil {
+		log.Printf("[DEBUG] Found OAuth credentials: clientID=%s", config.ClientID)
+		
+		// Get audience from environment or use default
+		audience := "https://api.cribl-playground.cloud"
+		if os.Getenv("CRIBL_AUDIENCE") != "" {
+			audience = os.Getenv("CRIBL_AUDIENCE")
+			log.Printf("[DEBUG] Using audience from environment: %s", audience)
+		} else {
+			log.Printf("[DEBUG] Using default audience: %s", audience)
+		}
+
+		// Get or create session
+		sessionKey := fmt.Sprintf("%s:%s", config.ClientID, config.ClientSecret)
+		var token string
+		if cachedToken, ok := o.sessions.Load(sessionKey); ok {
+			token = cachedToken.(string)
+			log.Printf("[DEBUG] Using cached token")
+		} else {
+			// Get new token
+			newToken, err := o.getBearerToken(config.ClientID, config.ClientSecret, audience)
+			if err != nil {
+				log.Printf("[ERROR] Failed to get bearer token: %v", err)
+				return req, err
+			}
+			token = newToken
+			o.sessions.Store(sessionKey, token)
+			log.Printf("[DEBUG] Got new token and cached it")
+		}
+
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else {
+		log.Printf("[DEBUG] No OAuth credentials found")
+	}
+
+	return req, nil
+}
+
+func (o *CriblTerraformAuthHook) getCredentialsFromConfig() (*CriblConfig, error) {
+	// First try environment variables
+	clientID := os.Getenv("CRIBL_CLIENT_ID")
+	clientSecret := os.Getenv("CRIBL_CLIENT_SECRET")
+
+	if clientID != "" && clientSecret != "" {
+		log.Printf("[DEBUG] Found credentials in environment variables")
+		return &CriblConfig{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+		}, nil
+	}
+
+	// Then try ~/.cribl file
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get home directory: %v", err)
+	}
+
+	configPath := filepath.Join(homeDir, ".cribl")
+	file, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file: %v", err)
+	}
+
+	var config CriblConfig
+	if err := json.Unmarshal(file, &config); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %v", err)
+	}
+
+	log.Printf("[DEBUG] Found credentials in config file")
+	return &config, nil
+}
+
+func (o *CriblTerraformAuthHook) getBearerToken(clientID, clientSecret, audience string) (string, error) {
+	authURL := "https://login.cribl-playground.cloud/oauth/token"
+	
+	// Create form data
+	formData := url.Values{}
+	formData.Set("grant_type", "client_credentials")
+	formData.Set("client_id", clientID)
+	formData.Set("client_secret", clientSecret)
+	formData.Set("audience", audience)
+
+	req, err := http.NewRequest("POST", authURL, strings.NewReader(formData.Encode()))
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := o.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to make request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to get token: %s", string(body))
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	return result.AccessToken, nil
+} 

--- a/internal/sdk/internal/hooks/registration.go
+++ b/internal/sdk/internal/hooks/registration.go
@@ -9,10 +9,8 @@ package hooks
  */
 
 func initHooks(h *Hooks) {
-	// exampleHook := &ExampleHook{}
-
-	// h.registerSDKInitHook(exampleHook)
-	// h.registerBeforeRequestHook(exampleHook)
-	// h.registerAfterErrorHook(exampleHook)
-	// h.registerAfterSuccessHook(exampleHook)
+	// Register Cribl Terraform authentication hook
+	authHook := NewCriblTerraformAuthHook()
+	h.registerSDKInitHook(authHook)
+	h.registerBeforeRequestHook(authHook)
 }


### PR DESCRIPTION
# Cribl Terraform Authentication Hook

## Overview
Added a new authentication hook specifically for the Cribl Terraform provider that handles both bearer token and OAuth authentication. This hook provides a more robust and flexible authentication mechanism for the provider.

## Changes
- Created new `CriblTerraformAuthHook` to handle authentication
- Implemented support for both bearer token and OAuth authentication
- Added credential loading from:
  - Environment variables (`CRIBL_BEARER_TOKEN`, `CRIBL_CLIENT_ID`, `CRIBL_CLIENT_SECRET`, `CRIBL_AUDIENCE`)
  - `~/.cribl` config file
- Added token caching to improve performance
- Added detailed debug logging for better troubleshooting

## Authentication Flow
1. First checks for bearer token in environment variables
2. If no bearer token, checks for OAuth credentials in:
   - Environment variables
   - `~/.cribl` config file
3. If OAuth credentials found:
   - Gets or creates a token
   - Caches the token for reuse
   - Adds the token to the request

## Testing
To test the authentication:

1. Using bearer token:
```bash
export CRIBL_BEARER_TOKEN="your-token"
```

2. Using OAuth credentials:
```bash
export CRIBL_CLIENT_ID="your-client-id"
export CRIBL_CLIENT_SECRET="your-client-secret"
export CRIBL_AUDIENCE="your-audience"  # Optional, defaults to https://api.cribl-playground.cloud
```

3. Or using config file:
```bash
echo '{"client_id": "your-client-id", "client_secret": "your-client-secret"}' > ~/.cribl/credentials
```

## Debugging
Run the provider with debug logging to see detailed authentication information:
```bash
go run main.go --debug
```