### PR TITLE
URL Hook Implementation for Cribl Terraform Provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/.speakeasy/temp/
+**/.speakeasy/logs/
 .speakeasy/temp/
 .terraform
 .terraform*

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,10 +3,10 @@ id: b2744b7e-1ce3-478a-8c1f-0348b936141a
 management:
   docChecksum: 3bd5759622b767560b30a6d95d2ed425
   docVersion: 1.0.0
-  speakeasyVersion: 1.540.1
-  generationVersion: 2.593.4
-  releaseVersion: 0.11.10
-  configChecksum: e7c76a2f4286e41a086f36a3a206818e
+  speakeasyVersion: 1.541.2
+  generationVersion: 2.595.4
+  releaseVersion: 0.11.11
+  configChecksum: ae8e6d6fd6cedf24c05223edf7637dab
   published: true
 features:
   terraform:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -16,7 +16,7 @@ generation:
     oAuth2ClientCredentialsEnabled: true
     oAuth2PasswordEnabled: true
 terraform:
-  version: 0.11.10
+  version: 0.11.11
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,8 +1,8 @@
-speakeasyVersion: 1.540.1
+speakeasyVersion: 1.541.2
 sources:
     Cribl API Reference:
         sourceNamespace: cribl-api-reference
-        sourceRevisionDigest: sha256:b3aba3622db2cf4ab18173e8e2585299868503fa8dcf4ed4bd22bf27c58cfcd1
+        sourceRevisionDigest: sha256:1b41df5f3407f07bc4fe77798538037a193842913efe7aaa9e5bc09ead298f41
         sourceBlobDigest: sha256:f1673b088f5dc45a4d10fe7e57770df5969e6971b67f064fc970d81ed64056ac
         tags:
             - latest
@@ -11,7 +11,7 @@ targets:
     cribl-terraform:
         source: Cribl API Reference
         sourceNamespace: cribl-api-reference
-        sourceRevisionDigest: sha256:b3aba3622db2cf4ab18173e8e2585299868503fa8dcf4ed4bd22bf27c58cfcd1
+        sourceRevisionDigest: sha256:1b41df5f3407f07bc4fe77798538037a193842913efe7aaa9e5bc09ead298f41
         sourceBlobDigest: sha256:f1673b088f5dc45a4d10fe7e57770df5969e6971b67f064fc970d81ed64056ac
 workflow:
     workflowVersion: 1.0.0

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ terraform {
   required_providers {
     cribl-terraform = {
       source  = "speakeasy/cribl-terraform"
-      version = "0.11.10"
+      version = "0.11.11"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     cribl-terraform = {
       source  = "speakeasy/cribl-terraform"
-      version = "0.11.10"
+      version = "0.11.11"
     }
   }
 }

--- a/examples/pack/main.tf
+++ b/examples/pack/main.tf
@@ -8,11 +8,11 @@ terraform {
 
 provider "cribl-terraform" {
   # Configuration options
-  server_url ="https://app.cribl-playground.cloud/organizations/beautiful-nguyen-y8y4azd/workspaces/main/app/api/v1/m/default"
+  #server_url ="https://app.cribl-playground.cloud/organizations/beautiful-nguyen-y8y4azd/workspaces/main/app/api/v1/m/default"
 }
 
 resource "cribl-terraform_pack" "my_pack" {
-  description  = "example-pack-description-test"
+  description  = "example-pack-description-test-1"
   disabled     = false
   display_name = "example-pack-display-name-test"
   id           = "example-pack-id-1"

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     cribl-terraform = {
       source  = "speakeasy/cribl-terraform"
-      version = "0.11.10"
+      version = "0.11.11"
     }
   }
 }

--- a/examples/source/main.tf
+++ b/examples/source/main.tf
@@ -8,15 +8,69 @@ terraform {
 
 provider "cribl-terraform" {
   # Configuration options
-  server_url ="https://app.cribl-playground.cloud/organizations/beautiful-nguyen-y8y4azd/workspaces/main/app/api/v1/m/default"
+  #server_url ="https://app.cribl-playground.cloud/organizations/beautiful-nguyen-y8y4azd/workspaces/main/app/api/v1/m/default"
 }
 
-data "cribl-terraform_source" "my_source" {
+resource "cribl-terraform_source" "my_source" {
   id = "CriblMetrics"
+  input_tcp = {
+    auth_type = "manual"
+    breaker_rulesets = [
+      "..."
+    ]
+    connections = [
+      {
+        output   = "test"
+        pipeline = "test"
+      }
+    ]
+    description         = "test"
+    disabled            = false
+    enable_header       = false
+    enable_proxy_header = false
+    environment         = "test"
+    host                = "test"
+    id                  = "test"
+    max_active_cxn      = 5.5
+    metadata = [
+      {
+        name  = "test"
+        value = "test"
+      }
+    ]
+    pipeline = "test"
+    port     = 47674.49
+    pq = {
+      commit_frequency = 1.66
+      compress         = "none"
+      max_buffer_size  = 51.41
+      max_file_size    = 1000000
+      max_size         = 1000000
+      mode             = "always"
+      path             = "test"
+    }
+    pq_enabled = false
+    preprocess = {
+      args = [
+        "..."
+      ]
+      command  = "test"
+      disabled = false
+    }
+    send_to_routes         = false
+    socket_ending_max_wait = 6.18
+    socket_idle_timeout    = 0.36
+    socket_max_lifespan    = 5.19
+    stale_channel_flush_ms = 8063309.13
+    streamtags = [
+      "..."
+    ]
+    type = "tcp"
+  }
 }
 
 output "source_details" {
   value = {
-    count_total = data.cribl-terraform_source.my_source.count_total
+    id = cribl-terraform_source.my_source.id
   }
 } 

--- a/internal/sdk/.gitignore
+++ b/internal/sdk/.gitignore
@@ -1,3 +1,6 @@
+.DS_Store
+**/.speakeasy/temp/
+**/.speakeasy/logs/
 .speakeasy/temp/
 # .gitignore
 .speakeasy/reports

--- a/internal/sdk/criblterraform.go
+++ b/internal/sdk/criblterraform.go
@@ -417,9 +417,9 @@ func New(opts ...SDKOption) *CriblTerraform {
 		sdkConfiguration: sdkConfiguration{
 			Language:          "go",
 			OpenAPIDocVersion: "1.0.0",
-			SDKVersion:        "0.11.10",
-			GenVersion:        "2.593.4",
-			UserAgent:         "speakeasy-sdk/terraform 0.11.10 2.593.4 1.0.0 github.com/speakeasy/terraform-provider-cribl-terraform/internal/sdk",
+			SDKVersion:        "0.11.11",
+			GenVersion:        "2.595.4",
+			UserAgent:         "speakeasy-sdk/terraform 0.11.11 2.595.4 1.0.0 github.com/speakeasy/terraform-provider-cribl-terraform/internal/sdk",
 			ServerDefaults: map[string]map[string]string{
 				"cloud": {
 					"workspaceName":  "main",

--- a/internal/sdk/internal/hooks/cribl_terraform_url_hook.go
+++ b/internal/sdk/internal/hooks/cribl_terraform_url_hook.go
@@ -1,0 +1,142 @@
+package hooks
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+)
+
+const (
+	// Default environment values
+	defaultEnvironmentID = "cribl-playground.cloud"
+	defaultWorkerGroupID = "default"
+
+	// URL path constants
+	workerGroupsPath = "/workerGroups"
+	systemProjectsPath = "/system/projects"
+)
+
+// ResourceType represents the type of resource being accessed
+type ResourceType string
+
+const (
+	// Resource types
+	WorkerGroupResource ResourceType = "workerGroup"
+	SystemResource      ResourceType = "system"
+	ProjectResource     ResourceType = "project"
+	OtherResource       ResourceType = "other"
+)
+
+// workerGroupResources defines paths that should be routed to worker group URLs
+var workerGroupResources = []string{
+	"/packs",
+	"/routes",
+	"/pipeline",
+	"/functions",
+	"/lookups",
+	"/jobs",
+	"/collectors",
+	"/destinations",
+	"/sources",
+	"/system",
+}
+
+// CriblTerraformURLHook implements URL routing for Cribl Terraform API
+type CriblTerraformURLHook struct {
+	defaultBase *url.URL
+	wgBase      *url.URL
+}
+
+var (
+	_ sdkInitHook       = (*CriblTerraformURLHook)(nil)
+	_ beforeRequestHook = (*CriblTerraformURLHook)(nil)
+)
+
+// getEnvironmentValue gets an environment variable with a default fallback
+func getEnvironmentValue(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}
+
+// constructURL builds a URL with the given components
+func constructURL(envID, orgID, workspaceID, workerGroupID string) string {
+	return fmt.Sprintf("https://app.%s/organizations/%s/workspaces/%s/app/api/v1/m/%s",
+		envID,
+		orgID,
+		workspaceID,
+		workerGroupID,
+	)
+}
+
+// NewCriblTerraformURLHook creates a new URL hook for Cribl Terraform
+func NewCriblTerraformURLHook() *CriblTerraformURLHook {
+	envID := getEnvironmentValue("CRIBL_ENVIRONMENT_ID", defaultEnvironmentID)
+	orgID := getEnvironmentValue("CRIBL_ORGANIZATION_ID", "")
+	workspaceID := getEnvironmentValue("CRIBL_WORKSPACE_ID", "")
+	workerGroupID := getEnvironmentValue("CRIBL_WORKER_GROUP_ID", defaultWorkerGroupID)
+
+	// Construct the default URL
+	defaultURL := constructURL(envID, orgID, workspaceID, workerGroupID)
+
+	// Construct the worker group URL (without worker group ID)
+	wgURL := fmt.Sprintf("https://app.%s/organizations/%s/workspaces/%s/app/api/v1",
+		envID,
+		orgID,
+		workspaceID,
+	)
+
+	defaultBase, _ := url.Parse(defaultURL)
+	wgBase, _ := url.Parse(wgURL)
+
+	return &CriblTerraformURLHook{
+		defaultBase: defaultBase,
+		wgBase:      wgBase,
+	}
+}
+
+// SDKInit implements the sdkInitHook interface
+// It sets the base URL to the constructed default URL
+func (o *CriblTerraformURLHook) SDKInit(baseURL string, client HTTPClient) (string, HTTPClient) {
+	return o.defaultBase.String(), client
+}
+
+// getResourceType determines the type of resource being accessed
+func getResourceType(path string) ResourceType {
+	if strings.HasPrefix(path, workerGroupsPath) {
+		return WorkerGroupResource
+	}
+	if strings.Contains(path, systemProjectsPath) {
+		return ProjectResource
+	}
+	for _, resource := range workerGroupResources {
+		if strings.HasPrefix(path, resource) {
+			return SystemResource
+		}
+	}
+	return OtherResource
+}
+
+// BeforeRequest implements the beforeRequestHook interface
+// It modifies the request URL based on the path and resource type
+func (o *CriblTerraformURLHook) BeforeRequest(ctx BeforeRequestContext, req *http.Request) (*http.Request, error) {
+	path := req.URL.Path
+	resourceType := getResourceType(path)
+
+	switch resourceType {
+	case WorkerGroupResource:
+		// For worker group operations, use the base API URL
+		req.URL = o.wgBase.ResolveReference(req.URL)
+	case ProjectResource, SystemResource:
+		// For system/projects resources and worker group resources, use the worker group URL
+		req.URL = o.defaultBase.ResolveReference(req.URL)
+	default:
+		// For all other paths, use the base API URL
+		req.URL = o.wgBase.ResolveReference(req.URL)
+	}
+
+	return req, nil
+}

--- a/internal/sdk/internal/hooks/registration.go
+++ b/internal/sdk/internal/hooks/registration.go
@@ -13,4 +13,9 @@ func initHooks(h *Hooks) {
 	authHook := NewCriblTerraformAuthHook()
 	h.registerSDKInitHook(authHook)
 	h.registerBeforeRequestHook(authHook)
+
+	// Register Cribl Terraform URL hook
+	urlHook := NewCriblTerraformURLHook()
+	h.registerSDKInitHook(urlHook)
+	h.registerBeforeRequestHook(urlHook)
 }


### PR DESCRIPTION
# URL Hook Improvements for Cribl Terraform Provider

## Overview
This PR enhances the URL routing hook in the Cribl Terraform provider to better handle different resource types. The changes ensure proper URL construction for worker groups and their associated resources while making the code more robust and configurable.

## Changes

### URL Routing Logic
- Added proper handling for different resource types:
  - Worker group operations (`/workerGroups/*`)
  - System/Project resources (`/system/projects/*`)
  - Worker group resources (packs, routes, pipelines, etc.)
  - Other API operations
- Improved URL construction to handle both worker group and non-worker group contexts
- Added support for environment variable-based configuration



### Configuration
The hook now supports the following environment variables:
- `CRIBL_ENVIRONMENT_ID` (defaults to "cribl-playground.cloud")
- `CRIBL_ORGANIZATION_ID`
- `CRIBL_WORKSPACE_ID`
- `CRIBL_WORKER_GROUP_ID` (defaults to "default")

## Testing
The changes have been tested with:
- Worker group creation and management
- Resource creation under worker groups